### PR TITLE
Update to 19w46b snapshot

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.2.5-SNAPSHOT'
+	id 'fabric-loom' version '0.2.6-SNAPSHOT'
 	id 'maven-publish'
 }
 
@@ -18,7 +18,7 @@ minecraft {}
 
 dependencies {
 	minecraft			"com.mojang:minecraft:${project.minecraft_version}"
-	mappings			"net.fabricmc:yarn:${project.yarn_mappings}"
+	mappings			"net.fabricmc:yarn:${project.minecraft_version}+build.${project.yarn_build}"
 	modImplementation	"net.fabricmc:fabric-loader:${project.loader_version}"
 	modImplementation 	"net.fabricmc.fabric-api:fabric-events-lifecycle-v0:${project.cmd_version}"
 	modImplementation 	"net.fabricmc.fabric-api:fabric-api-base:${project.base_version}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,9 +2,9 @@
 org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
-minecraft_version=1.14.4
-yarn_mappings=1.14.4+build.3
-loader_version=0.4.8+build.158
+minecraft_version=19w46b
+yarn_build=1:v2
+loader_version=0.6.4+build.169
 
 # Mod Properties
 mod_version = 0.3

--- a/src/main/java/dev/vatuu/tesseract/api/DimensionRegistry.java
+++ b/src/main/java/dev/vatuu/tesseract/api/DimensionRegistry.java
@@ -3,6 +3,7 @@ package dev.vatuu.tesseract.api;
 import dev.vatuu.tesseract.impl.world.DimensionRegistryImpl;
 import net.minecraft.util.Identifier;
 import net.minecraft.world.World;
+import net.minecraft.world.biome.BiomeAccessType;
 import net.minecraft.world.dimension.Dimension;
 import net.minecraft.world.dimension.DimensionType;
 
@@ -12,5 +13,5 @@ public interface DimensionRegistry {
 
     static DimensionRegistry getInstance() { return DimensionRegistryImpl.getInstance(); }
 
-    DimensionType registerDimensionType(Identifier name, boolean hasSkyLight, BiFunction<World, DimensionType, ? extends Dimension> create);
+    DimensionType registerDimensionType(Identifier name, boolean hasSkyLight, BiFunction<World, DimensionType, ? extends Dimension> create, BiomeAccessType biomeAccessor);
 }

--- a/src/main/java/dev/vatuu/tesseract/impl/Tesseract.java
+++ b/src/main/java/dev/vatuu/tesseract/impl/Tesseract.java
@@ -8,6 +8,8 @@ import net.fabricmc.fabric.api.event.server.ServerStartCallback;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.biome.BiomeAccess;
+import net.minecraft.world.biome.HorizontalVoronoiBiomeAccessType;
 import net.minecraft.world.dimension.DimensionType;
 
 public class Tesseract implements ModInitializer {
@@ -23,7 +25,8 @@ public class Tesseract implements ModInitializer {
                     .forcedSpawnPoint(new BlockPos(0, 64, 0))
                     .renderSkybox(true)
                     .renderFog(false)
-                .build(w, t)
+                .build(w, t),
+                HorizontalVoronoiBiomeAccessType.INSTANCE
         );
 
         ServerStartCallback.EVENT.register((ci) -> {

--- a/src/main/java/dev/vatuu/tesseract/impl/extensions/mixins/MinecraftServerMixin.java
+++ b/src/main/java/dev/vatuu/tesseract/impl/extensions/mixins/MinecraftServerMixin.java
@@ -103,7 +103,7 @@ public abstract class MinecraftServerMixin {
     private void resetWorld(ServerWorld w){
         w.savingDisabled = true;
         try{
-            File f = w.dimension.getType().getFile(w.getSaveHandler().getWorldDir());
+            File f = w.dimension.getType().getSaveDirectory(w.getSaveHandler().getWorldDir());
             FileUtils.deleteDirectory(f);
         }catch(IOException e){
             e.printStackTrace();

--- a/src/main/java/dev/vatuu/tesseract/impl/world/DimensionBuilderImpl.java
+++ b/src/main/java/dev/vatuu/tesseract/impl/world/DimensionBuilderImpl.java
@@ -41,12 +41,12 @@ public class DimensionBuilderImpl implements DimensionBuilder {
     }
 
     public DimensionBuilderImpl renderFog(boolean shouldRenderFog){
-        dim.shouldRenderFog = (i1, i2) -> shouldRenderFog;
+        dim.isFogThick = (i1, i2) -> shouldRenderFog;
         return this;
     }
 
     public DimensionBuilderImpl renderFog(RenderFogFunction bi){
-        dim.shouldRenderFog = bi;
+        dim.isFogThick = bi;
         return this;
     }
 

--- a/src/main/java/dev/vatuu/tesseract/impl/world/DimensionRegistryImpl.java
+++ b/src/main/java/dev/vatuu/tesseract/impl/world/DimensionRegistryImpl.java
@@ -6,6 +6,7 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectArrayMap;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
 import net.minecraft.world.World;
+import net.minecraft.world.biome.BiomeAccessType;
 import net.minecraft.world.dimension.Dimension;
 import net.minecraft.world.dimension.DimensionType;
 
@@ -26,9 +27,9 @@ public class DimensionRegistryImpl implements DimensionRegistry {
         else return INSTANCE;
     }
 
-    public DimensionType registerDimensionType(Identifier name, boolean hasSkyLight, BiFunction<World, DimensionType, ? extends Dimension> create){
+    public DimensionType registerDimensionType(Identifier name, boolean hasSkyLight, BiFunction<World, DimensionType, ? extends Dimension> create, BiomeAccessType biomeAccessor){
         int id = registered.size() + 3;
-        TesseractDimensionType t = new TesseractDimensionType(id, name.getPath(), hasSkyLight, create);
+        TesseractDimensionType t = new TesseractDimensionType(id, name.getPath(), hasSkyLight, create, biomeAccessor);
         registered.put(id, t);
         return Registry.register(Registry.DIMENSION, id, name.toString(), t);
     }

--- a/src/main/java/dev/vatuu/tesseract/impl/world/DimensionSettings.java
+++ b/src/main/java/dev/vatuu/tesseract/impl/world/DimensionSettings.java
@@ -23,7 +23,7 @@ final class DimensionSettings {
     boolean shouldRenderSkybox = false;
     boolean vaporizeWater = false;
     float cloudHeight = 128.0f;
-    RenderFogFunction shouldRenderFog = (i1, i2) -> false;
+    RenderFogFunction isFogThick = (i1, i2) -> false;
     FogColourFunction fogColour = (f1, f2) -> Tesseract.getRgbColour(0, 0, 0);
     SpawnChunkPosFunction spawningBlockChunk = (pos, b) -> null;
     SpawnTopFunction topSpawningBlockPos = (i1, i2, b) -> null;
@@ -36,7 +36,7 @@ final class DimensionSettings {
         config.getLayers().add(new FlatChunkGeneratorLayer(1, Blocks.AIR));
         config.setBiome(Biomes.THE_VOID);
         config.updateLayerBlocks();
-        FixedBiomeSourceConfig biomeConfig = BiomeSourceType.FIXED.getConfig().setBiome(Biomes.THE_VOID);
+        FixedBiomeSourceConfig biomeConfig = BiomeSourceType.FIXED.getConfig(w.getLevelProperties()).setBiome(Biomes.THE_VOID);
 
         return ChunkGeneratorType.FLAT.create(w, BiomeSourceType.FIXED.applyConfig(biomeConfig), config);
     };

--- a/src/main/java/dev/vatuu/tesseract/impl/world/TesseractDimension.java
+++ b/src/main/java/dev/vatuu/tesseract/impl/world/TesseractDimension.java
@@ -38,7 +38,7 @@ public class TesseractDimension extends OverworldDimension {
     @Override public boolean hasVisibleSky() { return settings.shouldRenderSkybox; }
     @Override public Vec3d getFogColor(float f1, float f2) { return settings.fogColour.apply(f1, f2); }
     @Override public boolean canPlayersSleep() { return !settings.shouldBedsExplode; }
-    @Override public boolean shouldRenderFog(int i1, int i2) { return settings.shouldRenderFog.apply(i1, i2); }
+    @Override public boolean isFogThick(int i1, int i2) { return settings.isFogThick.apply(i1, i2); }
     @Override public DimensionType getType() { return type; }
 
     public DimensionState getSaveState() { return saveState; }

--- a/src/main/java/dev/vatuu/tesseract/impl/world/TesseractDimensionType.java
+++ b/src/main/java/dev/vatuu/tesseract/impl/world/TesseractDimensionType.java
@@ -2,13 +2,14 @@ package dev.vatuu.tesseract.impl.world;
 
 
 import net.minecraft.world.World;
+import net.minecraft.world.biome.BiomeAccessType;
 import net.minecraft.world.dimension.Dimension;
 import net.minecraft.world.dimension.DimensionType;
 
 import java.util.function.BiFunction;
 
 public class TesseractDimensionType extends DimensionType {
-    TesseractDimensionType(int id, String name, boolean hasSky, BiFunction<World, DimensionType, ? extends Dimension> create) {
-        super(id, name.toUpperCase(), name.toLowerCase(), create, hasSky);
+    TesseractDimensionType(int id, String name, boolean hasSky, BiFunction<World, DimensionType, ? extends Dimension> create, BiomeAccessType biomeAccessor) {
+        super(id, name.toUpperCase(), name.toLowerCase(), create, hasSky, biomeAccessor);
     }
 }


### PR DESCRIPTION
Quick PR that:
  - updates game version to 19w46b (latest 1.15 snapshot). 
  - updates project to use yarnv2 mappings
  - adds support for the new BiomeAccessType dimension property
  - fix mapping renames & fix changes to fog method